### PR TITLE
no-rot & other changes

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/ISpriteComponent.cs
@@ -217,8 +217,8 @@ namespace Robust.Client.GameObjects
         int GetLayerDirectionCount(ISpriteLayer layer);
 
         /// <summary>
-        ///     Calculate sprite bounding box in world-space coordinates.
+        ///     Calculate the rotated sprite bounding box in world-space coordinates.
         /// </summary>
-        Box2 CalculateBoundingBox(Matrix3 worldMatrix);
+        Box2Rotated CalculateRotatedBoundingBox(Vector2 worldPosition, Angle worldRotation, IEye? eye = null);
     }
 }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteBoundsOverlay.cs
@@ -84,10 +84,17 @@ namespace Robust.Client.GameObjects
 
                 foreach (var sprite in comp.SpriteTree.QueryAabb(localAABB))
                 {
-                    var worldMatrix = _entityManager.GetComponent<TransformComponent>(sprite.Owner).WorldMatrix;
-                    var bounds = sprite.CalculateBoundingBox(worldMatrix);
+                    var (worldPos, worldRot) = _entityManager.GetComponent<TransformComponent>(sprite.Owner).GetWorldPositionRotation();
+                    var bounds = sprite.CalculateRotatedBoundingBox(worldPos, worldRot);
+
+                    // Get scaled down bounds used to indicate the "south" of a sprite.
+                    // Or at least thats what I think they are meant to do.
+                    var localBound = bounds.Box;
+                    var smallLocal = localBound.Scale(0.2f).Translated(-new Vector2(0f, localBound.Extents.Y));
+                    var southIndicator = new Box2Rotated(smallLocal, bounds.Rotation, bounds.Origin);
+
                     handle.DrawRect(bounds, Color.Red.WithAlpha(0.2f));
-                    handle.DrawRect(bounds.Scale(0.2f).Translated(-new Vector2(0f, bounds.Extents.Y)), Color.Blue.WithAlpha(0.5f));
+                    handle.DrawRect(southIndicator, Color.Blue.WithAlpha(0.5f));
                 }
             }
         }

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -1628,7 +1628,7 @@ namespace Robust.Client.GameObjects
             // fast check for empty sprites
             if (!Visible || Layers.Count == 0)
             {
-                return new Box2Rotated(new Box2(worldPosition, worldPosition));
+                return new Box2Rotated(new Box2(worldPosition, worldPosition), Angle.Zero, worldPosition);
             }
 
             // we need to calculate bounding box taking into account all nested layers

--- a/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/RenderingTreeSystem.cs
@@ -292,7 +292,7 @@ namespace Robust.Client.GameObjects
                 var newMapTree = GetRenderTree(sprite.Owner);
                 // TODO: Temp PVS guard
                 var xform = EntityManager.GetComponent<TransformComponent>(sprite.Owner);
-                var (worldPos, worldRot, worldMatrix) = xform.GetWorldPositionRotationMatrix();
+                var (worldPos, worldRot) = xform.GetWorldPositionRotation();
 
                 if (float.IsNaN(worldPos.X) || float.IsNaN(worldPos.Y))
                 {
@@ -300,7 +300,7 @@ namespace Robust.Client.GameObjects
                     continue;
                 }
 
-                var aabb = SpriteAabbFunc(sprite, worldPos, worldRot, worldMatrix);
+                var aabb = SpriteAabbFunc(sprite, worldPos, worldRot);
 
                 // If we're on a new map then clear the old one.
                 if (oldMapTree != newMapTree)
@@ -367,18 +367,9 @@ namespace Robust.Client.GameObjects
         private Box2 SpriteAabbFunc(in SpriteComponent value)
         {
             var xform = EntityManager.GetComponent<TransformComponent>(value.Owner);
-            var (worldPos, worldRot, worldMatrix) = xform.GetWorldPositionRotationMatrix();
-            var bounds = new Box2Rotated(value.CalculateBoundingBox(worldMatrix), worldRot, worldPos);
-            var tree = GetRenderTree(value.Owner);
+            var (worldPos, worldRot) = xform.GetWorldPositionRotation();
 
-            if (tree == null)
-            {
-                return bounds.CalcBoundingBox();
-            }
-            else
-            {
-                return EntityManager.GetComponent<TransformComponent>(tree.Owner).InvWorldMatrix.TransformBox(bounds);
-            }
+            return SpriteAabbFunc(value, worldPos, worldRot);
         }
 
         private Box2 LightAabbFunc(in PointLightComponent value)
@@ -400,10 +391,11 @@ namespace Robust.Client.GameObjects
             return Box2.CenteredAround(localPos, (boxSize, boxSize));
         }
 
-        private Box2 SpriteAabbFunc(SpriteComponent value, Vector2 worldPos, Angle worldRot, Matrix3 worldMatrix)
+        private Box2 SpriteAabbFunc(SpriteComponent value, Vector2 worldPos, Angle worldRot)
         {
-            var bounds = new Box2Rotated(value.CalculateBoundingBox(worldMatrix), worldRot, worldPos);
-            var tree = GetRenderTree(value.Owner);
+            var bounds = value.CalculateRotatedBoundingBox(worldPos, worldRot);
+
+            var tree =  GetRenderTree(value.Owner);
 
             if (tree == null)
             {

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -367,7 +367,7 @@ namespace Robust.Client.Graphics.Clyde
             uiProjmatrix.R0C2 = view.Size.X / 2f;
             uiProjmatrix.R1C2 = view.Size.Y / 2f;
 
-            var matrix = _currentMatrixView * uiProjmatrix;
+            var matrix = viewMatrix * uiProjmatrix;
 
             foreach (var comp in _entitySystemManager.GetEntitySystem<RenderingTreeSystem>().GetRenderTrees(map, worldBounds))
             {

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -1019,8 +1019,8 @@ namespace Robust.Client.Graphics.Clyde
                     return cmp;
                 }
 
-                // compare the bottom of the sprite's BB for y-sorting.
-                cmp = _drawList[x].Item4.Bottom.CompareTo(_drawList[y].Item4.Bottom);
+                // compare the top of the sprite's BB for y-sorting. Because screen coordinates are flipped, the "top" of the BB is actually the "bottom".
+                cmp = _drawList[x].Item4.Top.CompareTo(_drawList[y].Item4.Top);
 
                 if (cmp != 0)
                 {

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -1020,7 +1020,7 @@ namespace Robust.Client.Graphics.Clyde
                 }
 
                 // compare the bottom of the sprite's BB for y-sorting.
-                cmp = _drawList[y].Item4.Bottom.CompareTo(_drawList[x].Item4.Bottom);
+                cmp = _drawList[x].Item4.Bottom.CompareTo(_drawList[y].Item4.Bottom);
 
                 if (cmp != 0)
                 {

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -994,9 +994,9 @@ namespace Robust.Client.Graphics.Clyde
 
         private sealed class SpriteDrawingOrderComparer : IComparer<int>
         {
-            private readonly RefList<(SpriteComponent, Matrix3, Angle, float)> _drawList;
+            private readonly RefList<(SpriteComponent, Vector2, Angle, Box2)> _drawList;
 
-            public SpriteDrawingOrderComparer(RefList<(SpriteComponent, Matrix3, Angle, float)> drawList)
+            public SpriteDrawingOrderComparer(RefList<(SpriteComponent, Vector2, Angle, Box2)> drawList)
             {
                 _drawList = drawList;
             }
@@ -1019,7 +1019,8 @@ namespace Robust.Client.Graphics.Clyde
                     return cmp;
                 }
 
-                cmp = _drawList[y].Item4.CompareTo(_drawList[x].Item4);
+                // compare the bottom of the sprite's BB for y-sorting.
+                cmp = _drawList[y].Item4.Bottom.CompareTo(_drawList[x].Item4.Bottom);
 
                 if (cmp != 0)
                 {


### PR DESCRIPTION
Replaces `Sprite.CalculateBoundingBox` with `Sprite.CalculateRotatedBoundingBox`

Makes `ProcessSpriteEntities()` get the sprite's screen-BB rather than eye-frame-BB & keeps it for use with post-shaders

A chunk of this was me just fudging angles & matrices until it worked, so I  might be doing something stupid somewhere.

I don't really know how any of the rendering tree stuff works, but yeah I guess if that doesn't update as the player's eye rotates then no-rot sprites might be problematic?